### PR TITLE
Estop bug fix 

### DIFF
--- a/takin_estop/README.md
+++ b/takin_estop/README.md
@@ -34,6 +34,12 @@ If you're having issue with this package there might be two cause.
 link [https://jkjung-avt.github.io/gpio-non-root/] where it explain how 
 to change the permission to fix this issue. Then try to restart the node
 to see if it worked.
+
+Also it is worth noting that there's a udev rules that configure the 
+initial permission parameter on the GPIO pin 388. This file can be found
+ in the gpio folder of this package. This file should be place inside 
+ the /etc/udev/rules.d/ folder. 
+ 
 2. The ROS node is not behaving correctly, so there's a number of thing
 you should try to fix this
     1. Did you compile and source properly?

--- a/takin_estop/gpio/99-gpio.rules
+++ b/takin_estop/gpio/99-gpio.rules
@@ -1,3 +1,1 @@
-SUBSYSTEM=="bcm2835-gpiomem", KERNEL=="gpiomem", GROUP="gpio", MODE="0660"
-SUBSYSTEM=="gpio", KERNEL=="gpiochip*", ACTION=="add", PROGRAM="/bin/sh -c 'chown root:gpio /sys/class/gpio/export /sys/class/gpio/unexport ; chmod 220 /sys/class/gpio/export /sys/class/gpio/unexport'"
-SUBSYSTEM=="gpio", KERNEL=="gpio*", ACTION=="add", PROGRAM="/bin/sh -c 'chown root:gpio /sys%p/active_low /sys%p/direction /sys%p/edge /sys%p/value ; chmod 660 /sys%p/active_low /sys%p/direction /sys%p/edge /sys%p/value'"
+SUBSYSTEM=="gpio*", PROGRAM="/bin/sh -c 'chown -R root:gpio /sys/class/gpio && chmod -R 0220 /sys/class/gpio/export /sys/class/gpio/unexport;echo 388 > /sys/class/gpio/export; chown -R root:gpio /sys/class/gpio/gpio388; chmod -R g+wr /sys/class/gpio/gpio388/*;chown -R  root:gpio /sys/class/gpio/gpio388/*; chown -R root:gpio /sys/devices/virtual/gpio && chmod -R 770 /sys/devices/virtual/gpio'"


### PR DESCRIPTION
Travail fait : Ajout d'une udev rules pour donner les bonnes permissions aux fichiers de la pin GPIO.

Avez-vous bien documenté vos changements ? Il y a une partie de la documentation qui a été mise à jour.

Est-ce que ça été testé et comment? : Oui tester avec le multimètre après un redémarrage